### PR TITLE
[Sprint 10 / Hotfix] Revert Refactor for Atama

### DIFF
--- a/ninshiki_py/detector/tflite.py
+++ b/ninshiki_py/detector/tflite.py
@@ -132,7 +132,5 @@ class TfLite:
                     detection_object.top = y_min / img_height
                     detection_object.right = x_max / img_width
                     detection_object.bottom = y_max / img_height
-                    detection_object.img_width = img_width
-                    detection_object.img_height = img_height
 
                     detection_result.detected_objects.append(detection_object)

--- a/ninshiki_py/detector/yolo.py
+++ b/ninshiki_py/detector/yolo.py
@@ -111,8 +111,6 @@ class Yolo:
                         detection_object.top = y / frame_h
                         detection_object.right = (x+w) / frame_w
                         detection_object.bottom = (y+h) / frame_h
-                        detection_object.img_width = frame_w
-                        detection_object.img_height = frame_h
 
                         detection_result.detected_objects.append(detection_object)
 


### PR DESCRIPTION
## Jira Link: 

## Description

Revert the changes because camera_width and camera_height that are used for calculation in track object will be handled by Shisen, not Nishiki anymore.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [ ] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.